### PR TITLE
Adding total level message option

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.20'
+def runeLiteVersion = '1.9.13'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/discordnotifications/DiscordNotificationsConfig.java
+++ b/src/main/java/com/discordnotifications/DiscordNotificationsConfig.java
@@ -98,6 +98,24 @@ public interface DiscordNotificationsConfig extends Config {
 	default String andLevelMessage() { return ", and $skill to $level"; }
 
 	@ConfigItem(
+			keyName = "includeTotalLevelMessage",
+			name = "Include total level with message",
+			description = "Include total level in the message to send to Discord.",
+			section = levellingConfig,
+			position = 7
+	)
+	default boolean sendTotalLevel() { return false; }
+
+	@ConfigItem(
+			keyName = "totalLevelMessage",
+			name = "Total Level Message",
+			description = "Message to send to Discord when Total Level is included.",
+			section = levellingConfig,
+			position = 8
+	)
+	default String totalLevelMessage() { return " - Total Level: $total"; }
+
+	@ConfigItem(
 			keyName = "sendLevellingScreenshot",
 			name = "Include levelling screenshots",
 			description = "Include a screenshot when leveling up.",

--- a/src/main/java/com/discordnotifications/DiscordNotificationsPlugin.java
+++ b/src/main/java/com/discordnotifications/DiscordNotificationsPlugin.java
@@ -270,10 +270,15 @@ public class DiscordNotificationsPlugin extends Plugin
 			if(i != 0) {
 				levelUpString += config.andLevelMessage();
 			}
+			
+			if(config.sendTotalLevel()) {
+				levelUpString += config.totalLevelMessage();
+			}
 
 			String fixed = levelUpString
 					.replaceAll("\\$skill", skills[i])
-					.replaceAll("\\$level", currentLevels.get(skills[i]).toString());
+					.replaceAll("\\$level", currentLevels.get(skills[i]).toString())
+					.replaceAll("\\$total" , Integer.toString(client.getTotalLevel()));
 
 			levelUpString = fixed;
 		}


### PR DESCRIPTION
Simple toggle and text box to allow displaying total level as part of the leveling Discord message.

Really being able to parse _$total_ was the main requirement, but adding the check box and text box allows some customization from the player. Some friends and I are trying to max, so it's nice to keep track of each others totals when we see a Discord notification :) 

Thanks!