### PR TITLE
fix: screenshot requirement being checked twice, not sending message if not selected

### DIFF
--- a/src/main/java/com/discordnotifications/DiscordNotificationsPlugin.java
+++ b/src/main/java/com/discordnotifications/DiscordNotificationsPlugin.java
@@ -249,8 +249,7 @@ public class DiscordNotificationsPlugin extends Plugin
 				String bottomText = client.getVarcStrValue(VarClientStr.NOTIFICATION_BOTTOM_TEXT);
 
 				if (topText.equalsIgnoreCase("Collection log")
-						&& config.includeCollectionLogs()
-						&& config.sendCollectionLogScreenshot())
+						&& config.includeCollectionLogs())
 				{
 					String entry = Text.removeTags(bottomText).substring("New item:".length());
 					sendCollectionLogMessage(entry);
@@ -258,7 +257,6 @@ public class DiscordNotificationsPlugin extends Plugin
 
 				if (topText.equalsIgnoreCase("Combat Task Completed!")
 						&& config.includeCombatAchievements()
-						&& config.sendCombatAchievementsScreenshot()
 						&& client.getVarbitValue(Varbits.COMBAT_ACHIEVEMENTS_POPUP) == 0)
 				{
 					String[] s = bottomText.split("<.*?>");


### PR DESCRIPTION
It appears these lines are requiring the user to have selected Screenshot sending for both Collection Log and Combat Achievments notification in order to send the message to Discord.